### PR TITLE
feat: Implement `ResetReadiness` message and logic to reset party mem…

### DIFF
--- a/backend/cinematch-abi/src/domain/party/state_machine.rs
+++ b/backend/cinematch-abi/src/domain/party/state_machine.rs
@@ -99,6 +99,7 @@ impl PartyStateMachine for Party {
                     timeout_reason: None,
                     selected_movie_id,
                 };
+                ctx.broadcast_party(self.id, &ServerMessage::ResetReadiness, None);
                 ctx.broadcast_party(self.id, &ServerMessage::PartyStateChanged(msg), None);
             }
             PartyAdvanceOutcome::VotingEnded(EndVotingTransition::Round1Started) => {
@@ -127,6 +128,7 @@ impl PartyStateMachine for Party {
                     timeout_reason: None,
                     selected_movie_id,
                 };
+                ctx.broadcast_party(self.id, &ServerMessage::ResetReadiness, None);
                 ctx.broadcast_party(self.id, &ServerMessage::PartyStateChanged(msg), None);
             }
         }
@@ -175,9 +177,11 @@ impl PartyStateMachine for Party {
                             &ServerMessage::VotingRoundStarted(VotingRoundStarted { round: 2 }),
                             None,
                         );
+                        ctx.broadcast_party(self.id, &ServerMessage::ResetReadiness, None);
                         Some(PartyState::Voting) // Still in Voting state, just round 2
                     }
                     EndVotingTransition::PhaseChanged(s) => {
+                        ctx.broadcast_party(self.id, &ServerMessage::ResetReadiness, None);
                         // Let the catch-all below broadcast the PhaseChanged event
                         Some(*s)
                     }
@@ -243,6 +247,7 @@ impl PartyStateMachine for Party {
                     timeout_reason: None,
                     selected_movie_id,
                 };
+                ctx.broadcast_party(self.id, &ServerMessage::ResetReadiness, None);
                 ctx.broadcast_party(self.id, &ServerMessage::PartyStateChanged(msg), None);
             }
         }
@@ -456,6 +461,11 @@ async fn handle_round1_end(
     party.set_phase_entered_at_now(ctx).await.map_err(|e| {
         error!("Failed to update phase time: {}", e);
         DomainError::Internal("Failed to update phase time".into())
+    })?;
+
+    party.reset_ready_states(ctx).await.map_err(|e| {
+        error!("Failed to reset ready states for round 2: {}", e);
+        DomainError::Internal("Failed to reset ready states".into())
     })?;
 
     Ok(EndVotingTransition::Round2Started)

--- a/backend/cinematch-abi/src/scheduler/executor.rs
+++ b/backend/cinematch-abi/src/scheduler/executor.rs
@@ -134,6 +134,7 @@ async fn execute_voting_timeout<C: AppContext + Clone + 'static>(
                 None
             };
 
+            ctx.broadcast_party(party_id, &ServerMessage::ResetReadiness, None);
             ctx.broadcast_party(
                 party_id,
                 &ServerMessage::PartyStateChanged(PartyStateChanged {
@@ -176,6 +177,7 @@ async fn execute_watching_timeout<C: AppContext>(party: &Party, party_id: Uuid, 
         }
     };
 
+    ctx.broadcast_party(party_id, &ServerMessage::ResetReadiness, None);
     ctx.broadcast_party(
         party_id,
         &ServerMessage::PartyStateChanged(PartyStateChanged {
@@ -284,6 +286,7 @@ pub async fn execute_ready_countdown<C: AppContext + Clone + 'static>(
                 None
             };
 
+            ctx.broadcast_party(party_id, &ServerMessage::ResetReadiness, None);
             ctx.broadcast_party(
                 party_id,
                 &ServerMessage::PartyStateChanged(PartyStateChanged {

--- a/backend/cinematch-abi/src/scheduler/mod.rs
+++ b/backend/cinematch-abi/src/scheduler/mod.rs
@@ -372,10 +372,19 @@ impl Scheduler {
             // Note: This only cancels if it's a ready countdown (via reason check if we added it,
             // but for now, simple cancel is fine if we're in a phase that supports ready counts).
             // We should only cancel if it's a "Wait for all ready" countdown.
+            let state = party
+                .state(&ctx)
+                .await
+                .unwrap_or(cinematch_db::repo::party::models::PartyState::Disbanded);
+
             if self.is_scheduled(party_id).await {
-                // Check if the current timeout is a PhaseTimeout or ReadyCountdown.
-                // For now, if anyone becomes unready, we cancel.
-                self.cancel_and_broadcast(party_id, &ctx).await;
+                // Do NOT cancel the timeout if the party is in a timed phase (Voting/Watching).
+                // Unreadying should not cancel the voting countdown or watching timer.
+                if state != cinematch_db::repo::party::models::PartyState::Voting
+                    && state != cinematch_db::repo::party::models::PartyState::Watching
+                {
+                    self.cancel_and_broadcast(party_id, &ctx).await;
+                }
             }
         }
     }

--- a/backend/cinematch-common/src/models/websocket/server.rs
+++ b/backend/cinematch-common/src/models/websocket/server.rs
@@ -36,6 +36,7 @@ pub enum ServerMessage {
     PartyMemberLeft(Uuid),
     PartyStateChanged(PartyStateChanged),
     UpdateReadyState(ReadyStateUpdate),
+    ResetReadiness,
     PartyDisbanded,
 
     // Voting phase

--- a/frontend/src/components/party/PartyViewContext.tsx
+++ b/frontend/src/components/party/PartyViewContext.tsx
@@ -51,6 +51,8 @@ export function PartyViewProvider({
       if (msg === 'PartyDisbanded') {
         toast.info('The party has been disbanded')
         router.push('/dashboard')
+      } else if (msg === 'ResetReadiness') {
+        setMembers((prev) => prev.map((m) => ({ ...m, is_ready: false })))
       }
       return
     }

--- a/frontend/src/components/party/voting/VotingFlow.tsx
+++ b/frontend/src/components/party/voting/VotingFlow.tsx
@@ -5,7 +5,8 @@ import { CheckCircle2, XCircle } from 'lucide-react'
 import { useVoting } from '@/hooks/useVoting'
 import VotingCard from './VotingCard'
 import PhaseCountdown from '../PhaseCountdown'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { usePartyView } from '@/components/party/PartyViewContext'
 
 interface VotingFlowProps {
   partyId: string
@@ -17,7 +18,11 @@ interface VotingFlowProps {
 export default function VotingFlow({ partyId, phaseEnteredAt, timeoutSecs, deadlineAt }: Readonly<VotingFlowProps>) {
   const { movies, votingRound, voteTotals, loading, countdown, showContent, transitionData, handleVote, handleReady } =
     useVoting(partyId)
-  const [isVotingReady, setIsVotingReady] = useState(false)
+  const { members, currentUser } = usePartyView()
+  const serverReady = members.find((m) => m.user_id === currentUser.user_id)?.is_ready ?? false
+  const [isVotingReady, setIsVotingReady] = useState(serverReady)
+
+  useEffect(() => { setIsVotingReady(serverReady) }, [serverReady])
 
   if (loading || !showContent) {
     return (

--- a/frontend/src/lib/ws-types.ts
+++ b/frontend/src/lib/ws-types.ts
@@ -68,7 +68,8 @@ export type ServerMessage =
   | { PartyMemberLeft: string } // uuid string
   | { PartyStateChanged: PartyStateChangedPayload }
   | { UpdateReadyState: ReadyStateUpdatePayload }
-  | 'PartyDisbanded' // This might be serialized as a string "PartyDisbanded" if it has no payload
+  | 'PartyDisbanded'
+  | 'ResetReadiness'
   | { MovieVoteUpdate: MovieVotesPayload }
   | { VotingRoundStarted: VotingRoundStartedPayload }
   | { PartyTimeoutUpdate: PartyTimeoutUpdatePayload }


### PR DESCRIPTION
…ber readiness on state changes and timeouts, and prevent timeout cancellation during active voting or watching phases.